### PR TITLE
Compare lower case header names

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 
 ### Asset Pipeline
 
-Add the javascripts to your asset pipeline (for example application.js), preferrably after ember itself.
+Add the javascripts to your asset pipeline (for example application.js), preferably after ember itself.
 ```css
 //= require handlebars
 //= require ember
@@ -51,7 +51,7 @@ EmberRailsFlash.enable_flash_responder 'json'
 
 ### ember-cli
 
-First, install this repo throw bower:
+First, install this repo through bower:
 
 ```bash
 ember install:bower https://github.com/niklas/ember-rails-flash.git
@@ -86,7 +86,7 @@ Still learning, please educate me - SRSLY.
 
 For example like &#252;
 
-We transport the flash messages thorugh HTTP headers, which only support ASCII
+We transport the flash messages through HTTP headers, which only support ASCII
 encoding. So we encode the messages to HTML entities. To properly display these
 in your views, please use triple mustaches `{{{message}}}` for handlebars,
 triple equal signs `=== message` in Emblem or any other way which does not try
@@ -100,4 +100,3 @@ Caveat: You may now insert arbitrary JS and HTML in your flash messages.
 Feel free to open an issue ticket if you find something that could be improved.
 
 This project rocks and uses GPL-3 as license.
-

--- a/dist/ember-rails-flash.js
+++ b/dist/ember-rails-flash.js
@@ -26,10 +26,10 @@
       _results = [];
       for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
         header = _ref1[_i];
-        if (m = header.match(/^X-Flash-([^:]+)/)) {
+        if (m = header.toLowerCase().match(/^x-flash-([^:]+)/)) {
           _results.push(this.createMessage({
             severity: m[1].underscore(),
-            message: request.getResponseHeader("X-Flash-" + m[1])
+            message: request.getResponseHeader(m[0])
           }));
         } else {
           _results.push(void 0);

--- a/vendor/assets/javascripts/ember-rails-flash.js.coffee
+++ b/vendor/assets/javascripts/ember-rails-flash.js.coffee
@@ -12,8 +12,8 @@ Ember.Rails.FlashMessagesController = Ember.Controller.extend
   extractFlashFromHeaders: (request)->
     headers = request.getAllResponseHeaders()
     for header in headers.split(/\n/)
-      if m = header.match /^X-Flash-([^:]+)/
-        @createMessage severity: m[1].underscore(), message: request.getResponseHeader("X-Flash-#{m[1]}")
+      if m = header.toLowerCase().match /^x-flash-([^:]+)/
+        @createMessage severity: m[1].underscore(), message: request.getResponseHeader(m[0])
 
   createMessage: (args) ->
     message = Ember.Rails.FlashMessage.create args


### PR DESCRIPTION
`getAllResponseHeaders()` in Chrom(e|ium) 60 and Firefox 55 return lowercase header names which breaks the flash detection on Ember side.

Comparing only lower case header names work in older and newer browsers. Again flash messages in Ember :fireworks: 

[Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=716994)
[Firefox bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1348390)